### PR TITLE
Social media icons redirect to new tab: Resolves ISSUE #7

### DIFF
--- a/src/Components/LayoutComps/FooterComp.tsx
+++ b/src/Components/LayoutComps/FooterComp.tsx
@@ -41,6 +41,7 @@ const FooterComp = () => {
               <a
                 style={{ color: "white" }}
                 href="https://www.instagram.com/wohohiame/"
+                target="_blank"
               >
                 <svg
                   width="31"
@@ -66,6 +67,7 @@ const FooterComp = () => {
               <a
                 style={{ color: "white" }}
                 href="https://www.facebook.com/profile.php?id=100086186303060"
+                target="_blank"
               >
                 <svg
                   width="17"
@@ -91,6 +93,7 @@ const FooterComp = () => {
               <a
                 style={{ color: "white" }}
                 href="https://twitter.com/wohohiame"
+                target="_blank"
               >
                 <svg
                   width="38"


### PR DESCRIPTION
## Overview

Ensured clicking social media icons redirected to new tab

## Changes Made

Changed the footer component typescript file so that when social media icons are clicked, they go to a different file.

## Test Coverage

Manually tested by clicking the buttons in different orders and reloading the page.



## Related PRs or Issues (delete if not applicable)

#7 


##Screenshots


Populating the Database
![image](https://user-images.githubusercontent.com/50600962/223008416-864250e0-77e1-479c-b90d-c682f2e14457.png)

![image](https://user-images.githubusercontent.com/50600962/223008463-1e3d920b-f7be-4324-97cc-fb3096143db2.png)


